### PR TITLE
Make meetup card height flexible

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -329,7 +329,7 @@
   padding: 20px;
   width: calc(33.33% - 62px);
   min-width: 225px;
-  height: 120px;
+  min-height: 120px;
   background: var(--color-verylightBlue);
   border: 1px solid var(--color-lightBlue);
   margin: 10px;


### PR DESCRIPTION
Make meetup cards have a flexible height to avoid overflow and lack of margin.

Before:
![image](https://user-images.githubusercontent.com/357835/52797879-90ba6980-3055-11e9-9a21-fdffb7811a1b.png)

After:
![image](https://user-images.githubusercontent.com/357835/52797899-9dd75880-3055-11e9-9453-68682760b015.png)
